### PR TITLE
Dongtx/feature/manage cart

### DIFF
--- a/src/config/config.js
+++ b/src/config/config.js
@@ -1,4 +1,4 @@
-require('dotenv').config({ path: '/Users/shin/Documents/DemoProject/be_app/.env' });
+require('dotenv').config();
 
 module.exports = {
   "development": {
@@ -8,7 +8,7 @@ module.exports = {
     username: process.env.MYSQL_USER,     
     password: process.env.MYSQL_PASSWORD, 
     dialect: 'mysql',
-    logging: false  // Tắt SQL query logging
+    logging: false  
   },
   "test": {
     "username": "root",

--- a/src/config/config.js
+++ b/src/config/config.js
@@ -7,20 +7,23 @@ module.exports = {
     database: process.env.MYSQL_DATABASE, 
     username: process.env.MYSQL_USER,     
     password: process.env.MYSQL_PASSWORD, 
-    dialect: 'mysql'
+    dialect: 'mysql',
+    logging: false  // Tắt SQL query logging
   },
   "test": {
     "username": "root",
     "password": null,
     "database": "db_swp",
     "host": "127.0.0.1",
-    "dialect": "mysql"
+    "dialect": "mysql",
+    "logging": false
   },
   "production": {
     "username": "root",
     "password": null,
     "database": "database_production",
     "host": "127.0.0.1",
-    "dialect": "mysql"
+    "dialect": "mysql",
+    "logging": false
   }
 }

--- a/src/models/user.js
+++ b/src/models/user.js
@@ -62,11 +62,11 @@ module.exports = (sequelize, DataTypes) => {
         as: 'notifications'
       });
 
-      // User has many cart items
-      User.hasMany(models.CartItem, {
-        foreignKey: 'userId',
-        as: 'cartItems'
-      });
+      // User has many cart items through carts
+      // User.hasMany(models.CartItem, {
+      //   foreignKey: 'userId',
+      //   as: 'cartItems'
+      // });
     }
 
     // Instance methods

--- a/src/repositories/CartRepository.js
+++ b/src/repositories/CartRepository.js
@@ -43,24 +43,24 @@ class CartRepository extends RepositoryInterface {
             const cart = await this.Cart.findByPk(id, {
                 include: [
                     {
-                        model: this.db.CartItem,
+                        model: this.CartItem,
                         as: 'items',
                         include: [
                             {
-                                model: this.db.ProductVariant,
+                                model: this.ProductVariant,
                                 as: 'productVariant',
                                 include: [
                                     {
-                                        model: this.db.Product,
+                                        model: this.Product,
                                         as: 'product',
                                         include: [
                                             {
-                                                model: this.db.Brand,
+                                                model: this.Brand,
                                                 as: 'brand',
                                                 attributes: ['id', 'name', 'slug']
                                             },
                                             {
-                                                model: this.db.ProductImage,
+                                                model: this.ProductImage,
                                                 as: 'images',
                                                 attributes: ['id', 'imageUrl', 'altText', 'isPrimary'],
                                                 where: { isPrimary: true },
@@ -90,24 +90,24 @@ class CartRepository extends RepositoryInterface {
                 },
                 include: [
                     {
-                        model: this.db.CartItem,
+                        model: this.CartItem,
                         as: 'items',
                         include: [
                             {
-                                model: this.db.ProductVariant,
+                                model: this.ProductVariant,
                                 as: 'productVariant',
                                 include: [
                                     {
-                                        model: this.db.Product,
+                                        model: this.Product,
                                         as: 'product',
                                         include: [
                                             {
-                                                model: this.db.Brand,
+                                                model: this.Brand,
                                                 as: 'brand',
                                                 attributes: ['id', 'name', 'slug']
                                             },
                                             {
-                                                model: this.db.ProductImage,
+                                                model: this.ProductImage,
                                                 as: 'images',
                                                 attributes: ['id', 'imageUrl', 'altText', 'isPrimary'],
                                                 where: { isPrimary: true },
@@ -137,24 +137,24 @@ class CartRepository extends RepositoryInterface {
                 },
                 include: [
                     {
-                        model: this.db.CartItem,
+                        model: this.CartItem,
                         as: 'items',
                         include: [
                             {
-                                model: this.db.ProductVariant,
+                                model: this.ProductVariant,
                                 as: 'productVariant',
                                 include: [
                                     {
-                                        model: this.db.Product,
+                                        model: this.Product,
                                         as: 'product',
                                         include: [
                                             {
-                                                model: this.db.Brand,
+                                                model: this.Brand,
                                                 as: 'brand',
                                                 attributes: ['id', 'name', 'slug']
                                             },
                                             {
-                                                model: this.db.ProductImage,
+                                                model: this.ProductImage,
                                                 as: 'images',
                                                 attributes: ['id', 'imageUrl', 'altText', 'isPrimary'],
                                                 where: { isPrimary: true },
@@ -214,7 +214,7 @@ class CartRepository extends RepositoryInterface {
     async addItem(cartId, productVariantId, quantity, priceAtAdd) {
         try {
             // Check if item already exists in cart
-            const existingItem = await this.db.CartItem.findOne({
+            const existingItem = await this.CartItem.findOne({
                 where: {
                     cartId: cartId,
                     productVariantId: productVariantId
@@ -228,7 +228,7 @@ class CartRepository extends RepositoryInterface {
                 return existingItem;
             } else {
                 // Create new item
-                const cartItem = await this.db.CartItem.create({
+                const cartItem = await this.CartItem.create({
                     cartId: cartId,
                     productVariantId: productVariantId,
                     quantity: quantity,
@@ -248,7 +248,7 @@ class CartRepository extends RepositoryInterface {
                 return await this.removeItem(cartItemId);
             }
 
-            const cartItem = await this.db.CartItem.findByPk(cartItemId);
+            const cartItem = await this.CartItem.findByPk(cartItemId);
             if (!cartItem) {
                 throw new Error('Cart item not found');
             }
@@ -264,7 +264,7 @@ class CartRepository extends RepositoryInterface {
     // Remove item from cart
     async removeItem(cartItemId) {
         try {
-            const deleted = await this.db.CartItem.destroy({
+            const deleted = await this.CartItem.destroy({
                 where: { id: cartItemId }
             });
             return deleted > 0;
@@ -276,7 +276,7 @@ class CartRepository extends RepositoryInterface {
     // Clear all items from cart
     async clearCart(cartId) {
         try {
-            const deleted = await this.db.CartItem.destroy({
+            const deleted = await this.CartItem.destroy({
                 where: { cartId: cartId }
             });
             return deleted;
@@ -288,7 +288,7 @@ class CartRepository extends RepositoryInterface {
     // Update cart
     async update(id, updateData) {
         try {
-            await this.db.Cart.update(updateData, { where: { id } });
+            await this.Cart.update(updateData, { where: { id } });
             return await this.findById(id);
         } catch (error) {
             throw new Error(`Failed to update cart: ${error.message}`);
@@ -357,7 +357,7 @@ class CartRepository extends RepositoryInterface {
                 return await this.findById(userCart.id);
             } else {
                 // Transfer guest cart to user
-                await this.db.Cart.update(
+                await this.Cart.update(
                     { userId: userId, sessionId: null },
                     { where: { id: guestCart.id } }
                 );
@@ -391,19 +391,19 @@ class CartRepository extends RepositoryInterface {
                 where,
                 include: [
                     {
-                        model: this.db.CartItem,
+                        model: this.CartItem,
                         as: 'items',
                         include: [
                             {
-                                model: this.db.ProductVariant,
+                                model: this.ProductVariant,
                                 as: 'productVariant',
                                 include: [
                                     {
-                                        model: this.db.Product,
+                                        model: this.Product,
                                         as: 'product',
                                         include: [
                                             {
-                                                model: this.db.Brand,
+                                                model: this.Brand,
                                                 as: 'brand',
                                                 attributes: ['id', 'name', 'slug']
                                             }

--- a/src/repositories/CartRepository.js
+++ b/src/repositories/CartRepository.js
@@ -43,24 +43,24 @@ class CartRepository extends RepositoryInterface {
             const cart = await this.Cart.findByPk(id, {
                 include: [
                     {
-                        model: this.CartItem,
+                        model: this.db.CartItem,
                         as: 'items',
                         include: [
                             {
-                                model: this.ProductVariant,
+                                model: this.db.ProductVariant,
                                 as: 'productVariant',
                                 include: [
                                     {
-                                        model: this.Product,
+                                        model: this.db.Product,
                                         as: 'product',
                                         include: [
                                             {
-                                                model: this.Brand,
+                                                model: this.db.Brand,
                                                 as: 'brand',
                                                 attributes: ['id', 'name', 'slug']
                                             },
                                             {
-                                                model: this.ProductImage,
+                                                model: this.db.ProductImage,
                                                 as: 'images',
                                                 attributes: ['id', 'imageUrl', 'altText', 'isPrimary'],
                                                 where: { isPrimary: true },
@@ -90,24 +90,24 @@ class CartRepository extends RepositoryInterface {
                 },
                 include: [
                     {
-                        model: this.CartItem,
+                        model: this.db.CartItem,
                         as: 'items',
                         include: [
                             {
-                                model: this.ProductVariant,
+                                model: this.db.ProductVariant,
                                 as: 'productVariant',
                                 include: [
                                     {
-                                        model: this.Product,
+                                        model: this.db.Product,
                                         as: 'product',
                                         include: [
                                             {
-                                                model: this.Brand,
+                                                model: this.db.Brand,
                                                 as: 'brand',
                                                 attributes: ['id', 'name', 'slug']
                                             },
                                             {
-                                                model: this.ProductImage,
+                                                model: this.db.ProductImage,
                                                 as: 'images',
                                                 attributes: ['id', 'imageUrl', 'altText', 'isPrimary'],
                                                 where: { isPrimary: true },
@@ -137,24 +137,24 @@ class CartRepository extends RepositoryInterface {
                 },
                 include: [
                     {
-                        model: this.CartItem,
+                        model: this.db.CartItem,
                         as: 'items',
                         include: [
                             {
-                                model: this.ProductVariant,
+                                model: this.db.ProductVariant,
                                 as: 'productVariant',
                                 include: [
                                     {
-                                        model: this.Product,
+                                        model: this.db.Product,
                                         as: 'product',
                                         include: [
                                             {
-                                                model: this.Brand,
+                                                model: this.db.Brand,
                                                 as: 'brand',
                                                 attributes: ['id', 'name', 'slug']
                                             },
                                             {
-                                                model: this.ProductImage,
+                                                model: this.db.ProductImage,
                                                 as: 'images',
                                                 attributes: ['id', 'imageUrl', 'altText', 'isPrimary'],
                                                 where: { isPrimary: true },
@@ -214,7 +214,7 @@ class CartRepository extends RepositoryInterface {
     async addItem(cartId, productVariantId, quantity, priceAtAdd) {
         try {
             // Check if item already exists in cart
-            const existingItem = await this.CartItem.findOne({
+            const existingItem = await this.db.CartItem.findOne({
                 where: {
                     cartId: cartId,
                     productVariantId: productVariantId
@@ -228,7 +228,7 @@ class CartRepository extends RepositoryInterface {
                 return existingItem;
             } else {
                 // Create new item
-                const cartItem = await this.CartItem.create({
+                const cartItem = await this.db.CartItem.create({
                     cartId: cartId,
                     productVariantId: productVariantId,
                     quantity: quantity,
@@ -248,7 +248,7 @@ class CartRepository extends RepositoryInterface {
                 return await this.removeItem(cartItemId);
             }
 
-            const cartItem = await this.CartItem.findByPk(cartItemId);
+            const cartItem = await this.db.CartItem.findByPk(cartItemId);
             if (!cartItem) {
                 throw new Error('Cart item not found');
             }
@@ -264,7 +264,7 @@ class CartRepository extends RepositoryInterface {
     // Remove item from cart
     async removeItem(cartItemId) {
         try {
-            const deleted = await this.CartItem.destroy({
+            const deleted = await this.db.CartItem.destroy({
                 where: { id: cartItemId }
             });
             return deleted > 0;
@@ -276,7 +276,7 @@ class CartRepository extends RepositoryInterface {
     // Clear all items from cart
     async clearCart(cartId) {
         try {
-            const deleted = await this.CartItem.destroy({
+            const deleted = await this.db.CartItem.destroy({
                 where: { cartId: cartId }
             });
             return deleted;
@@ -288,7 +288,7 @@ class CartRepository extends RepositoryInterface {
     // Update cart
     async update(id, updateData) {
         try {
-            await this.Cart.update(updateData, { where: { id } });
+            await this.db.Cart.update(updateData, { where: { id } });
             return await this.findById(id);
         } catch (error) {
             throw new Error(`Failed to update cart: ${error.message}`);
@@ -357,7 +357,7 @@ class CartRepository extends RepositoryInterface {
                 return await this.findById(userCart.id);
             } else {
                 // Transfer guest cart to user
-                await this.Cart.update(
+                await this.db.Cart.update(
                     { userId: userId, sessionId: null },
                     { where: { id: guestCart.id } }
                 );
@@ -391,19 +391,19 @@ class CartRepository extends RepositoryInterface {
                 where,
                 include: [
                     {
-                        model: this.CartItem,
+                        model: this.db.CartItem,
                         as: 'items',
                         include: [
                             {
-                                model: this.ProductVariant,
+                                model: this.db.ProductVariant,
                                 as: 'productVariant',
                                 include: [
                                     {
-                                        model: this.Product,
+                                        model: this.db.Product,
                                         as: 'product',
                                         include: [
                                             {
-                                                model: this.Brand,
+                                                model: this.db.Brand,
                                                 as: 'brand',
                                                 attributes: ['id', 'name', 'slug']
                                             }

--- a/src/repositories/ProductRepository.js
+++ b/src/repositories/ProductRepository.js
@@ -11,6 +11,7 @@ class ProductRepository extends RepositoryInterface {
         this.ProductImage = db.ProductImage;
         this.ProductVariant = db.ProductVariant;
         this.Review = db.Review;
+        this.User = db.User;
         this.model = db.Product; // For interface compatibility
     }
 
@@ -73,7 +74,7 @@ class ProductRepository extends RepositoryInterface {
                         attributes: ['id', 'rating', 'title', 'comment', 'createdAt'],
                         include: [
                             {
-                                model: this.db.User,
+                                model: this.User,
                                 attributes: ['id', 'firstName', 'lastName']
                             }
                         ]
@@ -124,7 +125,7 @@ class ProductRepository extends RepositoryInterface {
                         attributes: ['id', 'rating', 'title', 'comment', 'createdAt'],
                         include: [
                             {
-                                model: this.db.User,
+                                model: this.User,
                                 attributes: ['id', 'firstName', 'lastName']
                             }
                         ]

--- a/src/services/CartService.js
+++ b/src/services/CartService.js
@@ -67,10 +67,10 @@ class CartService extends ServiceInterface {
     async addToCart(cartId, productVariantId, quantity = 1) {
         try {
             // Validate product variant exists and is active
-            const productVariant = await this.cartRepository.db.ProductVariant.findByPk(productVariantId, {
+            const productVariant = await this.productRepository.ProductVariant.findByPk(productVariantId, {
                 include: [
                     {
-                        model: this.cartRepository.db.Product,
+                        model: this.productRepository.Product,
                         as: 'product',
                         where: { isActive: true }
                     }
@@ -111,10 +111,10 @@ class CartService extends ServiceInterface {
                 throw new Error('Quantity cannot be negative');
             }
 
-            const cartItem = await this.cartRepository.db.CartItem.findByPk(cartItemId, {
+            const cartItem = await this.cartRepository.CartItem.findByPk(cartItemId, {
                 include: [
                     {
-                        model: this.cartRepository.db.ProductVariant,
+                        model: this.cartRepository.ProductVariant,
                         as: 'productVariant'
                     }
                 ]
@@ -147,7 +147,7 @@ class CartService extends ServiceInterface {
     // Remove item from cart
     async removeFromCart(cartItemId) {
         try {
-            const cartItem = await this.cartRepository.db.CartItem.findByPk(cartItemId);
+            const cartItem = await this.cartRepository.CartItem.findByPk(cartItemId);
             if (!cartItem) {
                 throw new Error('Cart item not found');
             }
@@ -266,7 +266,7 @@ class CartService extends ServiceInterface {
             for (const item of cart.items) {
                 const currentPrice = item.productVariant.price;
                 if (currentPrice !== item.priceAtAdd) {
-                    await this.cartRepository.db.CartItem.update(
+                    await this.cartRepository.CartItem.update(
                         { priceAtAdd: currentPrice },
                         { where: { id: item.id } }
                     );

--- a/src/services/CartService.js
+++ b/src/services/CartService.js
@@ -67,10 +67,10 @@ class CartService extends ServiceInterface {
     async addToCart(cartId, productVariantId, quantity = 1) {
         try {
             // Validate product variant exists and is active
-            const productVariant = await this.productRepository.db.ProductVariant.findByPk(productVariantId, {
+            const productVariant = await this.cartRepository.db.ProductVariant.findByPk(productVariantId, {
                 include: [
                     {
-                        model: this.productRepository.db.Product,
+                        model: this.cartRepository.db.Product,
                         as: 'product',
                         where: { isActive: true }
                     }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Refactors CartService and ProductRepository to use model accessors instead of db.*, removes direct User->CartItem association, switches dotenv to default path, and disables Sequelize logging across environments.
> 
> - **Backend**:
>   - **CartService**: Replace `cartRepository.db.*` and `productRepository.db.*` usages with repository model properties (e.g., `CartItem`, `ProductVariant`, `Product`).
>   - **ProductRepository**: Add `this.User` and use it in `reviews.user` includes.
>   - **User model**: Comment out direct `User.hasMany(models.CartItem, as: 'cartItems')` association.
> - **Config**:
>   - Load env with default `dotenv.config()` (remove hardcoded path).
>   - Add `logging: false` to Sequelize configs for `development`, `test`, and `production`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f8a3dd5e6571cada34dc8c28b6cc8c21f11c2f96. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->